### PR TITLE
PascalCase instead of camelCase with first letter capitalized

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Scala is an incredibly powerful language that is capable of many paradigms. We h
 
 We mostly follow Java's and Scala's standard naming conventions.
 
-- Classes, traits, objects should follow Java class convention, i.e. CamelCase style with the first letter capitalized.
+- Classes, traits, objects should follow Java class convention, i.e. PascalCase style.
   ```scala
   class ClusterManager
 
@@ -98,9 +98,9 @@ We mostly follow Java's and Scala's standard naming conventions.
   }
   ```
 
-- Enums should be CamelCase with first letter capitalized.
+- Enums should be PascalCase.
 
-- Annotations should also follow Java convention, i.e. CamelCase with first letter capitalized. Note that this differs from Scala's official guide.
+- Annotations should also follow Java convention, i.e. PascalCase. Note that this differs from Scala's official guide.
   ```scala
   final class MyAnnotation extends StaticAnnotation
   ```


### PR DESCRIPTION
Motivation:
Using camelCase with first letter capitalized addendum is misleading. Because in documentations of programming languages and style guides camelCase implies lowercase first letter.
Quotes from [wikipedia][wiki]:
"Camel case may start with a capital or, especially in programming languages, with a lowercase letter."
"In Microsoft documentation, camel case always starts with a lower case letter (e.g. backColor), and it is contrasted with PascalCase which always begins with a capital letter (e.g. BackColor)."
"Although the first letter of a camel case compound word may or may not be capitalized, the term camel case generally implies lowercase first letter."
[In Scala documentation][scala], it's also the lowercase first letter.

Modifications:
I changed the "camelCase with first letter capitalized" description to "PascalCase".

Result:
So that camelCase won't be misleading as PascalCase clearly defines that the first letter of each word is capitalized.

  [wiki]: https://en.wikipedia.org/wiki/CamelCase
  [scala]: http://docs.scala-lang.org/style/naming-conventions.html