### PR TITLE
Added Anonymous Methods section

### DIFF
--- a/README-KO.md
+++ b/README-KO.md
@@ -24,6 +24,7 @@ Scala는 매우 강력하며 여러가지 페러다임에 적용 가능한 언�
     - [Imports](#imports)
     - [패턴 매칭](#pattern-matching)
     - [중위 표기](#infix)
+    - [익명 함수](#anonymous)
   2. [Scala 언어의 기능](#lang)
     - [apply 함수](#apply_method)
     - [override 수정자](#override_modifier)
@@ -69,9 +70,10 @@ Scala는 매우 강력하며 여러가지 페러다임에 적용 가능한 언�
 - 2015-03-16: 초기 버전.
 - 2015-05-25: [override 수정자](#override_modifier) 섹션 추가.
 - 2015-08-23: "do NOT"에서 "avoid"으로 심각도 낮춤.
-- 2015-11-17: [apply 함수](#apply_method) 섹션 추가:  한 객체의 apply 함수는 그 객체와 같은 이름을 가진 클래스를 반환해야 합니다.
+- 2015-11-17: [apply 함수](#apply_method) 섹션 갱신:  한 객체의 apply 함수는 그 객체와 같은 이름을 가진 클래스를 반환해야 합니다.
 - 2015-11-17: 이 가이드라인이 [중국어로 번역되었습니다](README-ZH.md). 중국어 번역은 커뮤니티 맴버인 [Hawstein](https://github.com/Hawstein) 이 했습니다. 이 문서의 최신성을 보장하지 않습니다.
 - 2015-12-14: 이 가이드라인이 [한국어로 번역되었습니다](README-KO.md). 한국어 번역은 [Hyukjin Kwon](https://github.com/HyukjinKwon) 이 했으며, [Yun Park](https://github.com/yunpark93), [Kevin (Sangwoo) Kim](https://github.com/swkimme), [Hyunje Jo](https://github.com/RetrieverJo) 그리고 [Woocheol Choi](https://github.com/socialpercon) 가 검토를 했습니다. 이 문서의 최신성을 보장하지 않습니다.
+- 2016-06-15: [익명 함수](#anonymous) 섹션 추가.
 
 ## <a name='syntactic'>구문 스타일</a>
 
@@ -367,6 +369,32 @@ string contains "foo"
 
 // But overloaded operators should be invoked in infix style
 arrayBuffer += elem
+```
+
+### <a name='anonymous'>익명 함수</a>
+
+익명 함수를 위한 __여분의 소괄호 및 중괄호를 피합니다__.
+```scala
+// Correct
+list.map { item =>
+  ...
+}
+
+// Correct
+list.map(item => ...)
+
+// Wrong
+list.map(item => {
+  ...
+})
+
+// Wrong
+list.map { item => {
+  ...
+}}
+
+// Wrong
+list.map({ item => ... })
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ arrayBuffer += elem
 
 ### <a name='anonymous'>Anonymous Methods</a>
 
-__Avoid extra parentheses and curly braces__ for anonymous methods.
+__Avoid excessive parentheses and curly braces__ for anonymous methods.
 ```scala
 // Correct
 list.map { item =>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Scala is an incredibly powerful language that is capable of many paradigms. We h
     - [Imports](#imports)
     - [Pattern Matching](#pattern-matching)
     - [Infix Methods](#infix)
+    - [Anonymous Methods](#anonymous)
   2. [Scala Language Features](#lang)
     - [apply Method](#apply_method)
     - [override Modifier](#override_modifier)
@@ -72,6 +73,7 @@ Scala is an incredibly powerful language that is capable of many paradigms. We h
 - 2015-11-17: Updated [apply Method](#apply_method) section: apply method in companion object should return the companion class.
 - 2015-11-17: This guide has been [translated into Chinese](README-ZH.md). The Chinese translation is contributed by community member [Hawstein](https://github.com/Hawstein). We do not guarantee that it will always be kept up-to-date.
 - 2015-12-14:  This guide has been [translated into Korean](README-KO.md). The Korean translation is contributed by [Hyukjin Kwon](https://github.com/HyukjinKwon) and reviewed by [Yun Park](https://github.com/yunpark93), [Kevin (Sangwoo) Kim](https://github.com/swkimme), [Hyunje Jo](https://github.com/RetrieverJo) and [Woochel Choi](https://github.com/socialpercon). We do not guarantee that it will always be kept up-to-date.
+- 2016-06-15: Added [Anonymous Methods](#anonymous) section.
 
 ## <a name='syntactic'>Syntactic Style</a>
 
@@ -364,6 +366,33 @@ string contains "foo"
 
 // But overloaded operators should be invoked in infix style
 arrayBuffer += elem
+```
+
+
+### <a name='anonymous'>Anonymous Methods</a>
+
+__Avoid extra parentheses and curly braces__ for anonymous methods.
+```scala
+// Correct
+list.map { item =>
+  ...
+}
+
+// Correct
+list.map(item => ...)
+
+// Wrong
+list.map(item => {
+  ...
+})
+
+// Wrong
+list.map { item => {
+  ...
+}}
+
+// Wrong
+list.map({ item => ... })
 ```
 
 


### PR DESCRIPTION
This PR adds `Anonymous Methods` section.

I remember this [thread](https://mail-archives.apache.org/mod_mbox/spark-dev/201604.mbox/%3CCAMFhwAa3UEeSgi+Kb8-Ts6Buuz0oiRRGNLaT+2DdJb0uUZADNQ@mail.gmail.com%3E) and it seems the below style is preferred:

```
.map { item => 
  ...
}
```

rather than:

```
.map(item => {
  ...
})
```

I made other similar cases after reading the official language specification for anonymous functions, [here](http://www.scala-lang.org/files/archive/spec/2.11/06-expressions.html#anonymous-functions) and a blog [here](http://blog.mpieciukiewicz.pl/2013/07/scala-parentheses-and-curly-brackets-in.html).