### PR TITLE
Search and replace: elasped -> elapsed

### DIFF
--- a/README-KO.md
+++ b/README-KO.md
@@ -1170,15 +1170,15 @@ class JavaFriendlyAPI {
   val elapsedNs = System.nanoTime() - beginNs
 
   // 아래 예와 같이 하지 않습니다. 아래는 매직 넘버를 사용하고 있어서 쉽게 실수 할 수 있습니다.
-  val elapsedMs = elaspedNs / 1000 / 1000
+  val elapsedMs = elapsedNs / 1000 / 1000
 
   // 아래 예와 같이 Java의 TimeUnit API 를 사용합니다.
   import java.util.concurrent.TimeUnit
-  val elapsedMs2 = TimeUnit.NANOSECONDS.toMillis(elaspedNs)
+  val elapsedMs2 = TimeUnit.NANOSECONDS.toMillis(elapsedNs)
 
   // 아래 예와 같이 Scala의 Duration API를 사용합니다.
   import scala.concurrent.duration._
-  val elapsedMs3 = elaspedNs.nanos.toMillis
+  val elapsedMs3 = elapsedNs.nanos.toMillis
   ```
 
 예외 경우:

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -1238,15 +1238,15 @@ class JavaFriendlyAPI {
   val elapsedNs = System.nanoTime() - beginNs
 
   // 不要使用下面这种方式。这种方法容易出错
-  val elapsedMs = elaspedNs / 1000 / 1000
+  val elapsedMs = elapsedNs / 1000 / 1000
 
   // 推荐方法：使用Java TimeUnit API
   import java.util.concurrent.TimeUnit
-  val elapsedMs2 = TimeUnit.NANOSECONDS.toMillis(elaspedNs)
+  val elapsedMs2 = TimeUnit.NANOSECONDS.toMillis(elapsedNs)
 
   // 推荐方法：使用Scala Duration API
   import scala.concurrent.duration._
-  val elapsedMs3 = elaspedNs.nanos.toMillis
+  val elapsedMs3 = elapsedNs.nanos.toMillis
   ```
 
 例外：

--- a/README.md
+++ b/README.md
@@ -1174,15 +1174,15 @@ When there is an existing well-tesed method and it doesn't cause any performance
   val elapsedNs = System.nanoTime() - beginNs
 
   // This is WRONG. It uses magic numbers and is pretty easy to make mistakes
-  val elapsedMs = elaspedNs / 1000 / 1000
+  val elapsedMs = elapsedNs / 1000 / 1000
 
   // Use the Java TimeUnit API. This is CORRECT
   import java.util.concurrent.TimeUnit
-  val elapsedMs2 = TimeUnit.NANOSECONDS.toMillis(elaspedNs)
+  val elapsedMs2 = TimeUnit.NANOSECONDS.toMillis(elapsedNs)
 
   // Use the Scala Duration API. This is CORRECT
   import scala.concurrent.duration._
-  val elapsedMs3 = elaspedNs.nanos.toMillis
+  val elapsedMs3 = elapsedNs.nanos.toMillis
   ```
 
 Exceptions:


### PR DESCRIPTION
Did not notice that they were on the right-hand side, too. Did a proper search and replace now. :-)